### PR TITLE
Add a JSON summary reporter

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,7 +79,7 @@ function writeProfile(bench: Readonly<IBenchmarkCase>, profile: object) {
 }
 
 function printReporters() {
-  Object.keys(reporters).map(key => {
-    process.stdout.write(`${key.padStart(15)} - ${reporters[key].description}`);
-  });
+  for (const [name, reporter] of Object.entries(reporters)) {
+    process.stdout.write(`${name.padStart(15)} - ${reporter.description}\r\n`);
+  }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { cpuProfiler } from './middleware/cpu-profiler';
 import { IBenchmarkCase } from './suite';
 import { promisify } from 'util';
 import { writeFile } from 'fs';
+import { EOL } from 'os';
 
 interface IArgs {
   reporters?: boolean;
@@ -80,6 +81,6 @@ function writeProfile(bench: Readonly<IBenchmarkCase>, profile: object) {
 
 function printReporters() {
   for (const [name, reporter] of Object.entries(reporters)) {
-    process.stdout.write(`${name.padStart(15)} - ${reporter.description}\r\n`);
+    process.stdout.write(`${name.padStart(15)} - ${reporter.description}${EOL}`);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export { CsvReporter } from './reporters/csv';
 export { JsonReporter } from './reporters/json';
 export { PrettyReporter } from './reporters/pretty';
 export { GatherReporter } from './reporters/gather';
+export { JsonSummaryReporter } from './reporters/json-summary';
 export * from './middleware/grep';
 export * from './runner';
 export * from './options';

--- a/src/reporters/csv.ts
+++ b/src/reporters/csv.ts
@@ -1,4 +1,5 @@
 import { Benchmark, IReporter, IReporterFactory } from '.';
+import { EOL } from 'os';
 
 export const csvFactory: IReporterFactory = {
   description: 'Outputs stats as CSV',
@@ -7,7 +8,7 @@ export const csvFactory: IReporterFactory = {
 
 export class CsvReporter implements IReporter {
   constructor(private readonly out: NodeJS.WriteStream) {
-    out.write(['name', 'hz', 'mean', 'deviation', 'iterations'].join(',') + '\r\n');
+    out.write(['name', 'hz', 'mean', 'deviation', 'iterations'].join(',') + EOL);
   }
 
   onStartCycle() {
@@ -26,7 +27,7 @@ export class CsvReporter implements IReporter {
         benchmark.stats.mean.toFixed(8),
         benchmark.stats.deviation.toFixed(8),
         benchmark.count,
-      ].join(',') + '\r\n',
+      ].join(',') + EOL,
     );
   }
 

--- a/src/reporters/index.ts
+++ b/src/reporters/index.ts
@@ -1,6 +1,7 @@
 import OriginalBenchmark from 'benchmark';
 import { csvFactory } from './csv';
 import { jsonFactory } from './json';
+import { jsonSummaryFactory } from './json-summary';
 import { prettyFactory } from './pretty';
 
 export interface Benchmark extends OriginalBenchmark {
@@ -25,4 +26,5 @@ export const reporters: { [key: string]: IReporterFactory } = {
   csv: csvFactory,
   json: jsonFactory,
   pretty: prettyFactory,
+  'json-summary': jsonSummaryFactory,
 };

--- a/src/reporters/json-summary.ts
+++ b/src/reporters/json-summary.ts
@@ -1,0 +1,82 @@
+import { Benchmark, IReporter, IReporterFactory } from '.';
+
+type JsonResult = {
+  name: string;
+  factor: number;
+  ops: number;
+  fastest: boolean;
+};
+
+type JsonError = {
+  name: string;
+  error: Error['stack'];
+};
+
+export const jsonSummaryFactory: IReporterFactory = {
+  description: 'Outputs summarized stats as raw JSON',
+  start: () => new JsonSummaryReporter(process.stdout),
+};
+
+export class JsonSummaryReporter implements IReporter {
+  private readonly results: Benchmark[] = [];
+
+  constructor(private readonly out: NodeJS.WriteStream) {}
+
+  onStartCycle() {
+    // no-op
+  }
+
+  onFinishCycle(newResult: Benchmark) {
+    this.results.push(newResult);
+  }
+
+  onComplete() {
+    const benchmarks: Benchmark[] = [];
+    const results: JsonResult[] = [];
+    const errors: JsonError[] = [];
+
+    let minHz = Infinity;
+    let maxHz = 0;
+    let elapsed = 0;
+
+    for (const benchmark of this.results) {
+      elapsed += benchmark.times.elapsed;
+
+      if (benchmark.error) {
+        errors.push({ name: benchmark.name, error: benchmark.error.stack });
+      } else {
+        minHz = Math.min(minHz, benchmark.hz);
+        maxHz = Math.max(maxHz, benchmark.hz);
+        benchmarks.push(benchmark);
+      }
+    }
+
+    let fastest: Benchmark | undefined;
+
+    for (const benchmark of benchmarks) {
+      const factor = benchmark.hz / minHz;
+
+      if (!fastest && benchmark.hz === maxHz) {
+        fastest = benchmark;
+      }
+
+      results.push({
+        name: benchmark.name,
+        factor: Number(factor.toFixed(2)),
+        ops: Math.trunc(benchmark.hz),
+        fastest: benchmark === fastest,
+      });
+    }
+
+    const result = {
+      benches: this.results.length,
+      errors,
+      fastest: fastest?.name,
+      elapsed: Number(elapsed.toFixed(2)),
+      results,
+    };
+
+    this.out.write(JSON.stringify(result));
+    this.out.write('\r\n');
+  }
+}

--- a/src/reporters/json-summary.ts
+++ b/src/reporters/json-summary.ts
@@ -39,6 +39,7 @@ export class JsonSummaryReporter implements IReporter {
     let minHz = Infinity;
     let maxHz = 0;
     let elapsed = 0;
+    let fastest: Benchmark | undefined;
 
     for (const benchmark of this.results) {
       elapsed += benchmark.times.elapsed;
@@ -47,24 +48,23 @@ export class JsonSummaryReporter implements IReporter {
         errors.push({ name: benchmark.name, error: benchmark.error.stack });
       } else {
         minHz = Math.min(minHz, benchmark.hz);
-        maxHz = Math.max(maxHz, benchmark.hz);
+
+        if (benchmark.hz > maxHz) {
+          maxHz = benchmark.hz;
+          fastest = benchmark;
+        }
+
         benchmarks.push(benchmark);
       }
     }
 
-    let fastest: Benchmark | undefined;
-
     for (const benchmark of benchmarks) {
       const factor = benchmark.hz / minHz;
-
-      if (!fastest && benchmark.hz === maxHz) {
-        fastest = benchmark;
-      }
 
       results.push({
         name: benchmark.name,
         factor: Number(factor.toFixed(2)),
-        ops: Math.trunc(benchmark.hz),
+        ops: Number(benchmark.hz.toPrecision(3)),
         fastest: benchmark === fastest,
       });
     }

--- a/src/reporters/json-summary.ts
+++ b/src/reporters/json-summary.ts
@@ -1,4 +1,5 @@
 import { Benchmark, IReporter, IReporterFactory } from '.';
+import { EOL } from 'os';
 
 type JsonResult = {
   name: string;
@@ -77,6 +78,6 @@ export class JsonSummaryReporter implements IReporter {
     };
 
     this.out.write(JSON.stringify(result));
-    this.out.write('\r\n');
+    this.out.write(EOL);
   }
 }

--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -1,4 +1,5 @@
 import { Benchmark, IReporter, IReporterFactory } from '.';
+import { EOL } from 'os';
 
 export const jsonFactory: IReporterFactory = {
   description: 'Outputs stats as raw JSON',
@@ -21,7 +22,8 @@ export class JsonReporter implements IReporter {
 
     this.out.write(
       (this.printed++ > 0 ? ',' : '[') +
-        '\r\n  ' +
+        EOL +
+        '  ' +
         JSON.stringify({
           name: benchmark.name,
           hz: benchmark.hz,
@@ -33,6 +35,6 @@ export class JsonReporter implements IReporter {
   }
 
   onComplete() {
-    this.out.write('\r\n]\r\n');
+    this.out.write(`${EOL}]${EOL}`);
   }
 }

--- a/src/reporters/pretty.ts
+++ b/src/reporters/pretty.ts
@@ -1,6 +1,7 @@
 import { Benchmark, IReporter, IReporterFactory } from '.';
 import chalk from 'chalk';
 import { moveCursor, clearLine } from 'readline';
+import { EOL } from 'os';
 
 export const prettyFactory: IReporterFactory = {
   description: 'Pretty prints results to the console',
@@ -14,12 +15,12 @@ export class PrettyReporter implements IReporter {
   private readonly results: Benchmark[] = [];
 
   constructor(private readonly out: NodeJS.WriteStream) {
-    this.out.write('\r\n');
+    this.out.write(EOL);
   }
 
   onStartCycle(benchmark: Benchmark) {
     this.out.write(chalk.yellow('running > '.padStart(center)) + chalk.gray(benchmark.name));
-    this.out.write('\r\n');
+    this.out.write(EOL);
   }
 
   onFinishCycle(newResult: Benchmark) {
@@ -48,7 +49,7 @@ export class PrettyReporter implements IReporter {
         );
       }
 
-      this.out.write('\r\n');
+      this.out.write(EOL);
     }
   }
 
@@ -63,10 +64,10 @@ export class PrettyReporter implements IReporter {
     cases.sort((a, b) => b.hz - a.hz);
     const elapsed = cases.reduce((n, c) => n + c.times.elapsed, 0);
 
-    this.out.write('\r\n');
-    this.out.write(`  ${chalk.grey('Benches')}: ${cases.length}\r\n`);
-    this.out.write(`  ${chalk.grey('Fastest')}: ${(cases[0] as any)?.name}\r\n`);
-    this.out.write(`  ${chalk.grey('Elapsed')}: ${this.numberFormat.format(elapsed)}s\r\n`);
-    this.out.write('\r\n');
+    this.out.write(EOL);
+    this.out.write(`  ${chalk.grey('Benches')}: ${cases.length}${EOL}`);
+    this.out.write(`  ${chalk.grey('Fastest')}: ${(cases[0] as any)?.name}${EOL}`);
+    this.out.write(`  ${chalk.grey('Elapsed')}: ${this.numberFormat.format(elapsed)}s${EOL}`);
+    this.out.write(EOL);
   }
 }


### PR DESCRIPTION
I'm trying to generate HTML (or Markdown) tables from matcha reports but the default JSON output is too low-level and it requires a lot of postprocessing — postprocessing which is already implemented in the `pretty` reporter...

This reporter effectively provides the same human-friendly results as the `pretty` reporter, but emitted as JSON rather than colourful console output.

This PR also fixes the output of the `--reporters` option and avoids the use of a platform-specific line terminator.

## JSON

```
$ matcha -R json benchmark.js
```

```json
[
    {
        "name": "native(array)",
        "hz": 2098584.939301802,
        "mean": 4.765115679962421e-07,
        "deviation": 1.496583678801117e-08,
        "count": 108449
    },
    {
        "name": "join(array)",
        "hz": 3411881.597737768,
        "mean": 2.9309340648369664e-07,
        "deviation": 1.4236644969536652e-08,
        "count": 177913
    },
    {
        "name": "joiner(array)",
        "hz": 3650587.1129409587,
        "mean": 2.739285405503959e-07,
        "deviation": 1.2076272426493516e-08,
        "count": 190488
    },
    {
        "name": "join(iterable)",
        "hz": 4154345.884787892,
        "mean": 2.4071178176610995e-07,
        "deviation": 1.1509140748418417e-08,
        "count": 214557
    },
    {
        "name": "joiner(iterable)",
        "hz": 4161981.7933714944,
        "mean": 2.4027015245300496e-07,
        "deviation": 6.117142516150841e-09,
        "count": 213993
    }
]
```

### JSON Summary

```
$ matcha -R json-summary benchmark.js
```

```json
{
    "benches": 5,
    "errors": [],
    "fastest": "joiner(iterable)",
    "elapsed": 27.48,
    "results": [
        {
            "name": "native(array)",
            "factor": 1,
            "ops": 2039873,
            "fastest": false
        },
        {
            "name": "join(array)",
            "factor": 1.68,
            "ops": 3419421,
            "fastest": false
        },
        {
            "name": "joiner(array)",
            "factor": 1.76,
            "ops": 3587573,
            "fastest": false
        },
        {
            "name": "join(iterable)",
            "factor": 1.96,
            "ops": 3996732,
            "fastest": false
        },
        {
            "name": "joiner(iterable)",
            "factor": 2.02,
            "ops": 4110965,
            "fastest": true
        }
    ]
}
```