### PR TITLE
Enforce LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
This is needed because by default on Windows `autocrlf` is `true`.