### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  FORCE_COLOR: 2
+
+jobs:
+  test:
+    name: Node ${{ matrix.node }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [8, 10, 12, 14, 16]
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Compile
+        run: npm run compile
+
+      - name: Run tests
+        run: npm test

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "prettier": "^1.19.1",
     "typescript": "^3.7.3"
   },
+  "engines": {
+    "node": ">=8"
+  },
   "prettier": {
     "printWidth": 100,
     "singleQuote": true,

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# @c4312/matcha
+# @c4312/matcha [![CI](https://github.com/connor4312/matcha/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/connor4312/matcha/actions/workflows/ci.yml?query=branch%3Amaster)
 
 A modernization of [`matcha`](https://github.com/logicalparadox/matcha), powered by Benchmark.js. I found Matcha super useful over the years, but it has [issues with accuracy](https://github.com/logicalparadox/matcha/issues/22), doesn't support promises or work with Node 12, and is apparently abandoned. We fix those here!
 


### PR DESCRIPTION
CI preview until this is merged: https://github.com/XhmikosR/matcha/actions?query=branch%3Aci

I went with 8.x, but:

1. I think that everything should work from Node.js 6.x and newer (if so let me know and I can update the patch)
2. it would probably make sense to update everything later and switch to something like >= 12 :)